### PR TITLE
allow simulation of auth; sideload dispositions

### DIFF
--- a/queries/projects/lup-projects.sql
+++ b/queries/projects/lup-projects.sql
@@ -85,7 +85,7 @@ SELECT
     WHERE
       disp.dcp_project = p.dcp_projectid
       AND disp.dcp_recommendationsubmittedby = '${id:value}' -- plugs in contactid
-  ) AS project_dispositions,
+  ) AS dispositions,
   (
     SELECT json_agg(json_build_object(
       'dcp_name', m.dcp_name,
@@ -242,7 +242,7 @@ SELECT
         display_sequence,
         display_date
     ) AS m
-  ) AS project_milestones
+  ) AS milestones
 FROM lups_project_assignments AS lup
 LEFT JOIN
   dcp_project AS p ON p.dcp_projectid = lup.project_id

--- a/queries/projects/show.sql
+++ b/queries/projects/show.sql
@@ -357,7 +357,7 @@ SELECT
     FROM dcp_communityboarddisposition AS disp
     WHERE
       disp.dcp_project = p.dcp_projectid
-  ) AS lup_dispositions
+  ) AS dispositions
 FROM dcp_project p
 WHERE dcp_name = '${id:value}'
   AND dcp_visibility = 'General Public'

--- a/src/auth.middleware.ts
+++ b/src/auth.middleware.ts
@@ -15,11 +15,6 @@ export class AuthMiddleware implements NestMiddleware {
 
     const { token } = req.cookies;
 
-    // no token -- clear cookies and proceed unauthed
-    if (!token) {
-      return proceedNoAuth(res, next);
-    }
-
     try {
       req.session = await this.authService.validateCRMToken(token);
       next();

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -40,6 +40,12 @@ export class AuthService {
   }
 
   validateToken(token, secret): any {
+    const CRM_IMPOSTER_ID = this.config.get('CRM_IMPOSTER_ID');
+
+    if (this.config.get('SKIP_AUTH')) return {
+      contactid: CRM_IMPOSTER_ID
+    }
+
     try {
       return jwt.verify(token, secret);
     } catch (e) {

--- a/src/project/project.entity.ts
+++ b/src/project/project.entity.ts
@@ -2,8 +2,8 @@ import { Entity, Column, PrimaryColumn } from 'typeorm';
 
 @Entity('dcp_project')
 export class Project {
-  @PrimaryColumn()
-  dcp_projectid: number;
+  @PrimaryColumn({ name: 'dcp_projectid' })
+  projectid: number;
 
   @Column()
   milestones: string;
@@ -11,86 +11,86 @@ export class Project {
   @Column()
   actions: string;
 
-  @Column()
-  dcp_name: string;
+  @Column({ name: 'dcp_name' })
+  name: string;
 
-  @Column()
-  dcp_projectname: string;
+  @Column({ name: 'dcp_projectname' })
+  projectname: string;
 
-  @Column()
-  dcp_projectbrief: string;
+  @Column({ name: 'dcp_projectbrief' })
+  projectbrief: string;
 
-  @Column()
-  dcp_borough: string;
+  @Column({ name: 'dcp_borough' })
+  borough: string;
 
-  @Column()
-  dcp_communitydistricts: string;
+  @Column({ name: 'dcp_communitydistricts' })
+  communitydistricts: string;
 
-  @Column()
-  dcp_ulurp_nonulurp: string;
+  @Column({ name: 'dcp_ulurp_nonulurp' })
+  ulurp_nonulurp: string;
 
-  @Column()
-  dcp_leaddivision: string;
+  @Column({ name: 'dcp_leaddivision' })
+  leaddivision: string;
 
-  @Column()
-  dcp_ceqrtype: string;
+  @Column({ name: 'dcp_ceqrtype' })
+  ceqrtype: string;
 
-  @Column()
-  dcp_ceqrnumber: string;
+  @Column({ name: 'dcp_ceqrnumber' })
+  ceqrnumber: string;
 
-  @Column()
-  dcp_easeis: string;
+  @Column({ name: 'dcp_easeis' })
+  easeis: string;
 
-  @Column()
-  dcp_leadagencyforenvreview: string;
+  @Column({ name: 'dcp_leadagencyforenvreview' })
+  leadagencyforenvreview: string;
 
-  @Column()
-  dcp_alterationmapnumber: string;
+  @Column({ name: 'dcp_alterationmapnumber' })
+  alterationmapnumber: string;
 
-  @Column()
-  dcp_sischoolseat: string;
+  @Column({ name: 'dcp_sischoolseat' })
+  sischoolseat: string;
 
-  @Column()
-  dcp_sisubdivision: string;
+  @Column({ name: 'dcp_sisubdivision' })
+  sisubdivision: string;
 
-  @Column()
-  dcp_previousactiononsite: string;
+  @Column({ name: 'dcp_previousactiononsite' })
+  previousactiononsite: string;
 
-  @Column()
-  dcp_wrpnumber: string;
+  @Column({ name: 'dcp_wrpnumber' })
+  wrpnumber: string;
 
-  @Column()
-  dcp_nydospermitnumber: string;
+  @Column({ name: 'dcp_nydospermitnumber' })
+  nydospermitnumber: string;
 
-  @Column()
-  dcp_bsanumber: string;
+  @Column({ name: 'dcp_bsanumber' })
+  bsanumber: string;
 
-  @Column()
-  dcp_lpcnumber: string;
+  @Column({ name: 'dcp_lpcnumber' })
+  lpcnumber: string;
 
-  @Column()
-  dcp_decpermitnumber: string;
+  @Column({ name: 'dcp_decpermitnumber' })
+  decpermitnumber: string;
 
-  @Column()
-  dcp_femafloodzonea: string;
+  @Column({ name: 'dcp_femafloodzonea' })
+  femafloodzonea: string;
 
-  @Column()
-  dcp_femafloodzonecoastala: string;
+  @Column({ name: 'dcp_femafloodzonecoastala' })
+  femafloodzonecoastala: string;
 
-  @Column()
-  dcp_femafloodzonev: string;
+  @Column({ name: 'dcp_femafloodzonev' })
+  femafloodzonev: string;
 
-  @Column()
-  dcp_publicstatus_simp: string;
+  @Column({ name: 'dcp_publicstatus_simp' })
+  publicstatus_simp: string;
 
   @Column()
   actiontypes: string;
 
-  @Column()
-  dcp_certifiedreferred: string;
+  @Column({ name: 'dcp_certifiedreferred' })
+  certifiedreferred: string;
 
-  @Column()
-  dcp_femafloodzoneshadedx: string;
+  @Column({ name: 'dcp_femafloodzoneshadedx' })
+  femafloodzoneshadedx: string;
 
   @Column()
   applicants: string;

--- a/src/project/project.service.ts
+++ b/src/project/project.service.ts
@@ -150,12 +150,13 @@ export class ProjectService {
     let [project] = (records.length ? records : [records]);
     const [action = {}] = project.actions || [];
     const [milestone = {}] = project.milestones || [];
+    const [disposition = {}] = project.dispositions || [];
 
     // This is wrong... the wrong approach.
     const ProjectSerializer = new Serializer('projects', {
       id: 'dcp_name',
       attributes: Object.keys(project),
-      ...(action ? {     
+      ...(action ? {
         actions: {
           ref(project, action) {
             return `${project.dcp_name}-${action.actioncode}`;
@@ -163,12 +164,18 @@ export class ProjectService {
           attributes: Object.keys(action),
         },
       } : {}),
-      ...(milestone ? {   
+      ...(milestone ? {
         milestones: {
           ref(project, milestone) {
             return `${project.dcp_name}-${milestone.dcp_milestone}`;
           },
           attributes: Object.keys(milestone),
+        },
+      } : {}),
+      ...(milestone ? {
+        dispositions: {
+          ref: 'disposition_id',
+          attributes: Object.keys(disposition),
         },
       } : {}),
       meta: { ...opts },


### PR DESCRIPTION
This PR changes some alias names in the backing SQL queries, adds some initial aliases for the unrelated (and unimplemented) project entity (model), and allows for disabling authentication for development reasons.