### PR TITLE
221: improve query for projects that need geoms

### DIFF
--- a/src/project/geometries/geometries.service.ts
+++ b/src/project/geometries/geometries.service.ts
@@ -20,7 +20,11 @@ const getProjectsSQL = `
     AND d.dcp_name NOT IN (SELECT projectid FROM project_geoms)
     AND d.dcp_visibility = 'General Public'
     AND d.dcp_projectid IN (
-      SELECT DISTINCT dcp_project FROM dcp_projectbbl WHERE statuscode = 'Active')
+      SELECT DISTINCT dcp_project
+      FROM dcp_projectbbl
+      WHERE statuscode = 'Active'
+      AND modifiedon > (NOW() - interval '360 days')
+    )
   `;
 
 @Injectable()


### PR DESCRIPTION
The existing query for "Filed" projects that need geometries has been catching ~1800 old projects with BBLs that don't exist in the current version of MapPLUTO. This PR contains what seems to be a safe solution to the Carto and API timeout problems caused by the excessive doomed queries.

It adds a constraint to only looks at project BBL records that have been modified in the past year, therefore excluding old legacy BBL data that we can't match in MapPLUTO. I checked the query on the database, and this seems to be safe, conservative range. It returns zero results.

Addresses https://github.com/NYCPlanning/labs-zap-api/issues/221. Moving forward, we should still talk with Aline and LUR about other improvements we may be able to make to this geom create/update process, especially once we're collecting BBL data via the Applicant Portal.