### PR TITLE
fix applicant role query

### DIFF
--- a/migrations/1556727527249_create-materialized-view.js
+++ b/migrations/1556727527249_create-materialized-view.js
@@ -109,7 +109,7 @@ exports.up = (pgm) => {
       FROM dcp_projectapplicant pa
       LEFT JOIN account
       ON account.accountid = pa.dcp_applicant_customer
-      WHERE dcp_applicantrole IN ('Applicant', 'Co-Applicant')
+      WHERE dcp_applicantrole IN ('Applicant', 'Co-Applicant', 'Primary Applicant')
       AND pa.statuscode = 'Active'
       ORDER BY dcp_applicantrole ASC
     ) applicantteams

--- a/migrations/1557772355852_create-new-materialized-view.js
+++ b/migrations/1557772355852_create-new-materialized-view.js
@@ -110,7 +110,7 @@ exports.up = (pgm) => {
       FROM dcp_projectapplicant pa
       LEFT JOIN account
       ON account.accountid = pa.dcp_applicant_customer
-      WHERE dcp_applicantrole IN ('Applicant', 'Co-Applicant')
+      WHERE dcp_applicantrole IN ('Applicant', 'Co-Applicant', 'Primary Applicant')
       AND pa.statuscode = 'Active'
       ORDER BY dcp_applicantrole ASC
     ) applicantteams

--- a/migrations/materialized-view-definition.sql
+++ b/migrations/materialized-view-definition.sql
@@ -105,7 +105,7 @@ LEFT JOIN (
   FROM dcp_projectapplicant pa
   LEFT JOIN account
   ON account.accountid = pa.dcp_applicant_customer
-  WHERE dcp_applicantrole IN ('Applicant', 'Co-Applicant')
+  WHERE dcp_applicantrole IN ('Applicant', 'Co-Applicant', 'Primary Applicant')
   AND pa.statuscode = 'Active'
   ORDER BY dcp_applicantrole ASC
 ) applicantteams

--- a/queries/assignments/index.sql
+++ b/queries/assignments/index.sql
@@ -64,7 +64,7 @@ SELECT
       SELECT *
       FROM dcp_projectapplicant
       WHERE dcp_project = p.dcp_projectid
-        AND dcp_applicantrole IN ('Applicant', 'Co-Applicant')
+        AND dcp_applicantrole IN ('Applicant', 'Co-Applicant', 'Primary Applicant')
         AND statuscode = 'Active'
       ORDER BY dcp_applicantrole ASC
     ) pa
@@ -340,7 +340,7 @@ SELECT
             SELECT *
             FROM dcp_projectapplicant
             WHERE dcp_project = sub_project.dcp_projectid
-              AND dcp_applicantrole IN ('Applicant', 'Co-Applicant')
+              AND dcp_applicantrole IN ('Applicant', 'Co-Applicant', 'Primary Applicant')
               AND statuscode = 'Active'
             ORDER BY dcp_applicantrole ASC
           ) pa


### PR DESCRIPTION
Completes the fix to https://github.com/NYCPlanning/labs-zap-search/issues/876 by updating the normalized view and SQL queries that used the old dcp_applicantrole values. Applicant names were also missing on the main ZAP Search results page because the normalized view needed to be updated.